### PR TITLE
fix link to DC Image Setup page

### DIFF
--- a/_includes/dc/setup.html
+++ b/_includes/dc/setup.html
@@ -55,7 +55,7 @@ Image workshops
 
 {% elsif site.curriculum == "dc-image" %}
 
-<p>The setup instructions for Data Carpentry Image Processing workshops can be found at <a href="https://datacarpentry.org/image-processing/setup.html">the curriculum site</a></p>.
+<p>The setup instructions for Data Carpentry Image Processing workshops can be found at <a href="https://datacarpentry.org/image-processing/setup/">the curriculum site</a></p>.
 
 {% comment %}
 Social sciences workshops


### PR DESCRIPTION
Thank you for reporting this error. Merging this will fix the link to the Setup page, and I will not go and fix it in the workshop website template as well!